### PR TITLE
docs: update README with project overview and setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,40 @@
-# AngularGame
+# Angular Game
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 12.2.4.
+A small Bomberman-style game for the browser built with Angular and TypeScript. Move around the grid, drop bombs to remove obstacles and defeat roaming enemies, and collect bonuses for stronger explosions.
 
-## Development server
+## Technology
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+- [Angular](https://angular.io/) 12 with TypeScript
+- Assets for sprites and sound stored under `src/assets`
+- Docker configuration for containerised development
 
-## Code scaffolding
+## Getting Started
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+### Prerequisites
+- Node.js 16+ and npm
+- Alternatively Docker and Docker Compose
 
-## Build
+### Install & Run with Node
+```bash
+npm install
+npm start
+```
+Visit <http://localhost:4200> to play.
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+### Run with Docker
+```bash
+docker-compose up
+```
+This starts an Angular dev server on port 4200 inside a container.
 
-## Running unit tests
+### Build for Production
+```bash
+npm run build
+```
+The compiled output is placed in the `dist/` directory.
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
-
-## Running end-to-end tests
-
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
-
-## Further help
-
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.
+### Tests
+```bash
+npm test
+```
+Executes Karma/Jasmine unit tests (requires a local Chrome browser).


### PR DESCRIPTION
## Summary
- rewrite README with a concise project description
- document tech stack, local and Docker setup, build and test commands

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68baeeae9340832b87dda4ca57c046e8